### PR TITLE
Meerin toinen oksa

### DIFF
--- a/app.R
+++ b/app.R
@@ -382,7 +382,7 @@ ui <- navbarPage(
                                     label = "prosentteina",
                                     value = FALSE),
                       p("Valinnat vaikuttavat sekä viereiseen kuvaajaan että alapuolelta ladattavaan csv-tiedostoon."),
-                      p("Mikäli jonkin kuukauden tiedot eivät ole näkyvissä, tiedot on jouduttu peittämään tietosuojasyistä")
+                      p(strong("Huom!"),"Mikäli jonkin kuukauden tiedot eivät ole näkyvissä, tiedot on jouduttu peittämään liian pienen havaintomäärän takia.")
                     ),
 
                     # Create a spot for the barplot
@@ -408,7 +408,8 @@ ui <- navbarPage(
                       selectInput("top", "Valitse tarkasteltavien alojen lkm",
                                   choices= c(1:8),
                                   selected = 5),
-                      p("Valinnat vaikuttavat sekä viereiseen kuvaajaan että alapuolelta ladattavaan csv-tiedostoon.")
+                      p("Valinnat vaikuttavat sekä viereiseen kuvaajaan että alapuolelta ladattavaan csv-tiedostoon."),
+                      p(strong("Huom!"),"Mikäli jonkin kuukauden tiedot eivät ole näkyvissä, tiedot on jouduttu peittämään liian pienen havaintomäärän takia.")
                     ),
 
                     # Create a spot for the barplot

--- a/app.R
+++ b/app.R
@@ -343,9 +343,7 @@ ui <- navbarPage(
       title = "Taustaa datasta",
       #value = ,  #valueta käyteteään url muodostamiseen
       fluidPage(
-        fluidRow(
-          column(includeMarkdown("tekstit/dataselite.md"), width = 6),
-          column(width = 6)
+        fluidRow(includeMarkdown("tekstit/dataselite.md")
         ))
     )
  ),

--- a/app.R
+++ b/app.R
@@ -365,7 +365,7 @@ ui <- navbarPage(
        tabPanel("Ukrainalaiset Suomessa",
        fluidPage(
          column(includeMarkdown("tekstit/ukraina_etusivu.md"), width = 6),
-         column( h4("Tilapäisen suojelun piirissä olevien ukrainalaisten ikä- ja sukupuolijakauma"),
+         column( h3("Tilapäisen suojelun piirissä olevien ukrainalaisten ikä- ja sukupuolijakauma"),
                  plotlyOutput("ikaryhma"), width = 6)
        )),
        tabPanel("Taustatietoja",

--- a/tekstit/dataselite.md
+++ b/tekstit/dataselite.md
@@ -1,22 +1,25 @@
 ## Taustaa datasta
 
 ### Avoin sähködata
-
+<font size="4"> 
 Avoin data on peräisin Fingridin hallinnoimasta Avoin Data API:sta, joka tarjoaa reaaliaikaista sähköjärjestelmän dataa avoimessa muodossa. API sisältää tietoa esimerkiksi sähkönkulutuksesta, tuotannosta, siirrosta ja hintakehityksestä Suomessa. Tämän avoimen datan käyttö mahdollistaa reaaliaikaisen seurannan sähköjärjestelmän tilasta ja kulutuksesta.
 
 Tämä API on löydettävissä osoitteesta [https://data.fingrid.fi/fi/](https://data.fingrid.fi/fi/).
-
+</font> 
 
 ### Asuntokuntakohtainen sähkönkäyttö 
-
+<font size="4"> 
 Kotitalouksien mittarikohtainen sähkönkulutus saadaan Fingrid Datahub -aineistosta. Tiedostoissa esitetään luvut joulukuun 2022 kulutuksesta. Mittaripisteen sähkösopimus yhdistetään asuntokuntiin sähkösopimuksen haltijan pseudonymisoidun henkilönumeron avulla.
+</font> 
+
 
 #### Asuntokuntien määrittely
-
+<font size="4"> 
 Asuntokunnat on määritelty Tilastokeskuksen väestön ennakkotietojen mukaan. Asuntokunnan kotikunta määritellään vakituisen osoitteen sijaintikunnan perusteella. Asuntokunnan sähkönkulutus lasketaan kaikkien asuntokunnan hallussa olevien sähkösopimusten kulutuksesta, sillä asuntokunnalla voi olla useita sähkösopimuksia. Suurimmalla osalla asuntokunnista on kuitenkin vain yksi vakituiseen osoitteeseen tehty sähkösopimus. Aineistossa käsitellään vain niitä asuntokuntia, joilla on havaittu sähkösopimus ja vakituinen osoite. Aineistossa havaitaan noin 2,5 miljoonaa asuntokuntaa, kun taas noin 300 000 asuntokunnalla ei ole sähkösopimusta. Esimerkkejä sähkösopimuksettomista asuntokunnista ovat ne, joilla vuokranantaja tai joku muu taho maksaa sähkön.
 
 Asuntokunnat on jaettu tulokymmenyksiin henkilöiden perusteella siten, että kaikille asuntokunnan henkilöille on allokoitu asuntokunnan yhteenlasketut käytettävissä olevat tulot, ja henkilöt on järjestetty tulojen mukaiseen järjestykseen ja jaettu kymmeneen yhtä suureen joukkoon. Näin yhdessä tulokymmenyksessä on kymmenesosa henkilöistä, ei asuntokunnista.
 
 Asuntokunta määritellään sähkölämmittäjäksi, jos Fingridin tietojen mukaan sopimus, josta on havaittu eniten kulutusta, on sähkölämmitteisessä talossa. Mikäli asuntokunnalla on hallussaan useampi asunto, määritellään asuinmuoto myös sen mukaan, mistä suurin kulutus tulee. Mikäli suurin kulutus tulee kerrostaloasunnosta, valitaan asuntokunta kerrostaloasujaksi. 
 
+</font> 
 

--- a/tekstit/dataselite.md
+++ b/tekstit/dataselite.md
@@ -1,20 +1,22 @@
-## Taustaa datasta
+# Taustaa datasta
 
-### Avoin sähködata
+## Avoin sähködata
+
 <font size="4"> 
+
 Avoin data on peräisin Fingridin hallinnoimasta Avoin Data API:sta, joka tarjoaa reaaliaikaista sähköjärjestelmän dataa avoimessa muodossa. API sisältää tietoa esimerkiksi sähkönkulutuksesta, tuotannosta, siirrosta ja hintakehityksestä Suomessa. Tämän avoimen datan käyttö mahdollistaa reaaliaikaisen seurannan sähköjärjestelmän tilasta ja kulutuksesta.
 
 Tämä API on löydettävissä osoitteesta [https://data.fingrid.fi/fi/](https://data.fingrid.fi/fi/).
-</font> 
 
-### Asuntokuntakohtainen sähkönkäyttö 
-<font size="4"> 
+## Asuntokuntakohtainen sähkönkäyttö 
+
 Kotitalouksien mittarikohtainen sähkönkulutus saadaan Fingrid Datahub -aineistosta. Tiedostoissa esitetään luvut joulukuun 2022 kulutuksesta. Mittaripisteen sähkösopimus yhdistetään asuntokuntiin sähkösopimuksen haltijan pseudonymisoidun henkilönumeron avulla.
-</font> 
 
 
-#### Asuntokuntien määrittely
-<font size="4"> 
+
+### Asuntokuntien määrittely
+
+
 Asuntokunnat on määritelty Tilastokeskuksen väestön ennakkotietojen mukaan. Asuntokunnan kotikunta määritellään vakituisen osoitteen sijaintikunnan perusteella. Asuntokunnan sähkönkulutus lasketaan kaikkien asuntokunnan hallussa olevien sähkösopimusten kulutuksesta, sillä asuntokunnalla voi olla useita sähkösopimuksia. Suurimmalla osalla asuntokunnista on kuitenkin vain yksi vakituiseen osoitteeseen tehty sähkösopimus. Aineistossa käsitellään vain niitä asuntokuntia, joilla on havaittu sähkösopimus ja vakituinen osoite. Aineistossa havaitaan noin 2,5 miljoonaa asuntokuntaa, kun taas noin 300 000 asuntokunnalla ei ole sähkösopimusta. Esimerkkejä sähkösopimuksettomista asuntokunnista ovat ne, joilla vuokranantaja tai joku muu taho maksaa sähkön.
 
 Asuntokunnat on jaettu tulokymmenyksiin henkilöiden perusteella siten, että kaikille asuntokunnan henkilöille on allokoitu asuntokunnan yhteenlasketut käytettävissä olevat tulot, ja henkilöt on järjestetty tulojen mukaiseen järjestykseen ja jaettu kymmeneen yhtä suureen joukkoon. Näin yhdessä tulokymmenyksessä on kymmenesosa henkilöistä, ei asuntokunnista.

--- a/tekstit/etusivu.md
+++ b/tekstit/etusivu.md
@@ -1,5 +1,8 @@
 # VATT Datahuone
 
-Tervetuloa VATT Datahuoneen Shiny-sovellukseen! Alla esittelemme lyhyesti jokaisen osion sisältämät tiedot, jotta saat paremman käsityksen sovelluksen tarjoamista mahdollisuuksista ja voit hyödyntää sitä tehokkaasti.
+<font size="4"> 
+Tervetuloa VATT Datahuoneen Shiny-sovellukseen! 
 
-
+- Sähkönkäytön seurantaosiossa voit tarkastella suomalaisten kotitalouksien sähkönkulutusta. 
+- Työmarkkina-välilehden löydät tietoa tilapäisen suojelun piirissä olevista ukrainalaisista. 
+</font> 

--- a/tekstit/sahko_leipateksti.md
+++ b/tekstit/sahko_leipateksti.md
@@ -1,14 +1,19 @@
 <font size="4"> 
+
 Täältä voit tarkastella suomalaisten kotitalouksien sähkönkulutusta Fingrid Datahubin rekisteriaineistoilla tuotetun tiedon avulla, jotka on yhdistetty Tilastokeskuksen rekisteriaineistoihin.
+
 
 Osiossa "Reaaliaikainen sähkönkäyttötilanne" näet reaaliaikaiset tiedot sähkön käytöstä ja tuotannosta. Nämä tiedot ovat saatavilla Fingridin avoimesta data-verkkopalvelusta ja kattavat kaikki sähkönkäyttäjät.
 
+
 Suomen kotitalouksien sähkönkulutusta on mahdollista tarkastella eri tarkastelutasoilla. Osiossa "Kotitalouksien kokonaiskulutuksen trendit" esitellään maantieteellisten alueiden kokonaissähkönkulutusta sekä henkilökohtaista sähkönkulutusta.
+
 
 Osiossa "Sosioekonomisten muuttujien vaikutus" voit tarkastella esimerkiksi asuntokuntien tulotason, asumismuodon ja koon vaikutusta sähkönkulutukseen.
 
 
 Tavoitteenamme on tarjota käyttäjille mahdollisimman monipuolinen ja kattava näkymä Suomen kotitalouksien sähkönkulutukseen. Tiedot perustuvat Fingrid Datahubin tilastotietoihin, jotka olemme yhdistäneet Tilastokeskuksen rekisteriaineistoihin. Lisäksi olemme keränneet muita tietoja täydentämään näitä tilastoja, esimerkiksi Ilmatieteenlaitoksen säädataa sekä Fingridin avointa dataa. Toivomme, että sovelluksemme auttaa käyttäjiä ymmärtämään paremmin sähkönkulutuksen jakautumista ja siihen vaikuttavia tekijöitä eri tarkastelutasoilla.
+
 
 Huomaathan, että sivustomme kehitys on edelleen käynnissä. Jos huomaat virheitä tai haluat antaa kehitysehdotuksia, voit ottaa yhteyttä sähköpostiosoitteeseen datahuone[a]vatt.fi tai luoda bugiraportin tai pull requestin [GitHub-sivuillamme](https://github.com/bbtheo/Shiny_app_datahuone). Olemme kiitollisia kaikista palautteista, sillä se auttaa meitä kehittämään sovellustamme ja tarjoamaan käyttäjille entistä parempaa palvelua.
 

--- a/tekstit/sahko_leipateksti.md
+++ b/tekstit/sahko_leipateksti.md
@@ -1,3 +1,4 @@
+<font size="4"> 
 Täältä voit tarkastella suomalaisten kotitalouksien sähkönkulutusta Fingrid Datahubin rekisteriaineistoilla tuotetun tiedon avulla, jotka on yhdistetty Tilastokeskuksen rekisteriaineistoihin.
 
 Osiossa "Reaaliaikainen sähkönkäyttötilanne" näet reaaliaikaiset tiedot sähkön käytöstä ja tuotannosta. Nämä tiedot ovat saatavilla Fingridin avoimesta data-verkkopalvelusta ja kattavat kaikki sähkönkäyttäjät.
@@ -10,3 +11,5 @@ Osiossa "Sosioekonomisten muuttujien vaikutus" voit tarkastella esimerkiksi asun
 Tavoitteenamme on tarjota käyttäjille mahdollisimman monipuolinen ja kattava näkymä Suomen kotitalouksien sähkönkulutukseen. Tiedot perustuvat Fingrid Datahubin tilastotietoihin, jotka olemme yhdistäneet Tilastokeskuksen rekisteriaineistoihin. Lisäksi olemme keränneet muita tietoja täydentämään näitä tilastoja, esimerkiksi Ilmatieteenlaitoksen säädataa sekä Fingridin avointa dataa. Toivomme, että sovelluksemme auttaa käyttäjiä ymmärtämään paremmin sähkönkulutuksen jakautumista ja siihen vaikuttavia tekijöitä eri tarkastelutasoilla.
 
 Huomaathan, että sivustomme kehitys on edelleen käynnissä. Jos huomaat virheitä tai haluat antaa kehitysehdotuksia, voit ottaa yhteyttä sähköpostiosoitteeseen datahuone[a]vatt.fi tai luoda bugiraportin tai pull requestin [GitHub-sivuillamme](https://github.com/bbtheo/Shiny_app_datahuone). Olemme kiitollisia kaikista palautteista, sillä se auttaa meitä kehittämään sovellustamme ja tarjoamaan käyttäjille entistä parempaa palvelua.
+
+</font> 

--- a/tekstit/ukraina_etusivu.md
+++ b/tekstit/ukraina_etusivu.md
@@ -1,7 +1,8 @@
 
 ### Tilapäisen suojelun piirissä olevat ukrainalaiset Suomessa 
 
-- Tilastokeskuksen rekisteriaineistojen mukaan Suomeen on saapunut 31.3.2023 mennessä noin 45 000 ukrainalaista.
+Tilastokeskuksen rekisteriaineistojen mukaan Ukrainan sodan alettua Suomeen on saapunut noin 45 000 ukrainalaista (1.3.2023 mennessä)
+
 - Heistä suurin osa on naisia ja lapsia
 - Kotikunnan on 31.3.2023 mennessä saanut 2480 ukrainalaista
 - Suurin osa tilapäisen suojelun piirissä olevista ovat työllistyneet joko siivojiksi tai maa- ja metsätaloustöihin.

--- a/tekstit/ukraina_etusivu.md
+++ b/tekstit/ukraina_etusivu.md
@@ -1,14 +1,16 @@
 
 ### Tilapäisen suojelun piirissä olevat ukrainalaiset Suomessa 
 
+<font size="4"> 
 Tilastokeskuksen rekisteriaineistojen mukaan Ukrainan sodan alettua Suomeen on saapunut noin 45 000 ukrainalaista (1.3.2023 mennessä)
 
 - Heistä suurin osa on naisia ja lapsia
 - Kotikunnan on 31.3.2023 mennessä saanut 2480 ukrainalaista
 - Suurin osa tilapäisen suojelun piirissä olevista ovat työllistyneet joko siivojiksi tai maa- ja metsätaloustöihin.
-
+</font> 
 
 ### Lisätietoja
+<font size="4"> 
 Tässä tarkastelussa henkilö määritellään kuuluvan tilapäisen suojelun piiriin, jos hän on
 
 - Ukrainan kansalainen
@@ -26,5 +28,5 @@ Toimiala- ja ammattikohtaiseen tarkasteluun on otettu mukaan henkilöt, jotka ov
 
 
 
-
+</font> 
 


### PR DESCRIPTION
Muutettu tekstitiedostojen fonttikokoja isommaksi lisäämällä pötkö html-koodia tiedostojen alkuun ja loppuun. Voidaan korvata paremmalla ratkaisulla jos keksitään. 

Lisäksi:
- muokattu etusivun tekstiä
- lisätty ukrainavälilehdille huomiotäppä
- muutettu ukraina-kuvaajan otsikon fonttikokoa
- dataselite koko sivun laajuiseksi
